### PR TITLE
Add Qraphics+ API and CI. Warning, not tested

### DIFF
--- a/.github/workflows/build-ndk.yml
+++ b/.github/workflows/build-ndk.yml
@@ -1,0 +1,107 @@
+name: NDK build
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v2
+        name: Checkout
+        with:
+          submodules: true
+          lfs: true
+      - name: Install Powershell
+        run: sudo apt-get install -y powershell
+
+      #       - name: Cache Android NDK
+      #         id: cache-ndk
+      #         uses: actions/cache@v2
+      #         env:
+      #           cache-name: cache-ndk
+      #           ndkname: android-ndk-r22
+      #         with:
+      #           path: ndk
+      #           key: ${{ runner.os }}-${{ env.cache-name }}-${{ env.ndkname }}
+      #           restore-keys: |
+      #             ${{ runner.os }}-${{ env.cache-name }}-${{ env.ndkname }}
+
+      - name: Setup NDK
+        if: steps.cache-ndk.outputs.cache-hit != 'true'
+        id: setup-ndk
+        uses: nttld/setup-ndk@v1.0.3
+        with:
+          ndk-version: r22
+
+      - name: Create ndkpath.txt
+        run: echo ${{ steps.setup-ndk.outputs.ndk-path }} > ${GITHUB_WORKSPACE}/ndkpath.txt
+
+      #       - name: Cache QPM
+      #         id: cache-qpm
+      #         uses: actions/cache@v2
+      #         env:
+      #           cache-name: cache-qpm
+      #         with:
+      #           path: QPM/QPM_Temp
+      #           key: ${{ runner.os }}-qpm-${{ hashFiles('**/qpm.shared.json') }}
+      #           restore-keys: |
+      #             ${{ runner.os }}-qpm-
+
+      - name: Get QPM
+        if: steps.cache-qpm.outputs.cache-hit != 'true'
+        uses: dawidd6/action-download-artifact@v2
+        with:
+          github_token: ${{secrets.GITHUB_TOKEN}}
+          workflow: main.yml
+          name: QPM-ubuntu-x64
+          path: QPM
+          repo: sc2ad/QuestPackageManager
+
+      - name: QPM Make shared file
+        run: |
+          chmod +x ./QPM/QPM
+          ./QPM/QPM collect
+
+      - name: Cache QPM
+        id: cache-qpm-deps
+        uses: actions/cache@v2
+        with:
+          path: QPM/QPM_Temp
+          key: ${{ runner.os }}-qpm-${{ hashFiles('**/qpm.shared.json') }}
+          restore-keys: |
+            ${{ runner.os }}-qpm-
+
+      - name: QPM Restore
+        run: |
+          chmod +x ./QPM/QPM
+          ./QPM/QPM restore
+      - name: test
+        run: |
+          ls ./QPM/QPM_Temp
+      - name: Build
+        run: |
+          cd ${GITHUB_WORKSPACE}
+          pwsh -Command ./build.ps1
+      - name: Get Library Name
+        id: libname
+        run: |
+          cd ./libs/arm64-v8a/
+          pattern="libqraphicsplus*.so"
+          files=( $pattern )
+          echo ::set-output name=NAME::"${files[0]}"
+      - name: Upload non-debug artifact
+        uses: actions/upload-artifact@v2
+        with:
+          name: ${{ steps.libname.outputs.NAME }}
+          path: ./libs/arm64-v8a/${{ steps.libname.outputs.NAME }}
+          if-no-files-found: error
+      - name: Upload debug artifact
+        uses: actions/upload-artifact@v2
+        with:
+          name: debug_${{ steps.libname.outputs.NAME }}
+          path: ./obj/local/arm64-v8a/${{ steps.libname.outputs.NAME }}
+          if-no-files-found: error
+    # TODO: Add auto-populating releases, auto update versions, auto publish package on release

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,185 @@
+name: Publish QPM Package
+
+on:
+  push:
+    tags:
+      - 'v*'
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v2
+        name: Checkout
+        with:
+          submodules: true
+          lfs: true
+      - name: Install Powershell
+        run: sudo apt-get install -y powershell
+
+      #       - name: Cache Android NDK
+      #         id: cache-ndk
+      #         uses: actions/cache@v2
+      #         env:
+      #           cache-name: cache-ndk
+      #           ndkname: android-ndk-r22
+      #         with:
+      #           path: ndk
+      #           key: ${{ runner.os }}-${{ env.cache-name }}-${{ env.ndkname }}
+      #           restore-keys: |
+      #             ${{ runner.os }}-${{ env.cache-name }}-${{ env.ndkname }}
+
+      - name: Setup NDK
+        #         if: steps.cache-ndk.outputs.cache-hit != 'true'
+        id: setup-ndk
+        uses: nttld/setup-ndk@v1.0.3
+        with:
+          ndk-version: r22
+
+      - name: Create ndkpath.txt
+        run: echo ${{ steps.setup-ndk.outputs.ndk-path }} > ${GITHUB_WORKSPACE}/ndkpath.txt
+
+      - name: Get QPM
+        uses: dawidd6/action-download-artifact@v2
+        with:
+          github_token: ${{secrets.GITHUB_TOKEN}}
+          workflow: main.yml
+          name: QPM-ubuntu-x64
+          path: QPM
+          repo: sc2ad/QuestPackageManager
+
+      - name: QPM Make shared file
+        run: |
+          chmod +x ./QPM/QPM
+          ./QPM/QPM collect
+
+      - name: Cache QPM
+        id: cache-qpm-deps
+        uses: actions/cache@v2
+        with:
+          path: QPM/QPM_Temp
+          key: ${{ runner.os }}-qpm-${{ hashFiles('**/qpm.shared.json') }}
+          restore-keys: |
+            ${{ runner.os }}-qpm-
+
+      - name: QPM Restore
+        run: |
+          chmod +x ./QPM/QPM
+          ./QPM/QPM restore
+
+      - name: Get Tag Version
+        id: get_tag_version
+        run: |
+          echo ${GITHUB_REF#refs/tags/}
+          echo ::set-output name=TAG::${GITHUB_REF#refs/tags/}
+          echo ::set-output name=VERSION::${GITHUB_REF#refs/tags/v}
+
+      - name: QPM Edit Version
+        run: |
+          ./QPM/QPM package edit version "${{ steps.get_tag_version.outputs.VERSION }}"
+
+      - name: Build
+        run: |
+          cd ${GITHUB_WORKSPACE}
+          pwsh -Command ./build.ps1
+
+      # Commit the change to the package, .vscode/c_cpp_properties.json, and Android.mk
+      - name: Configure commit
+        run: |
+          git config user.name "Github Actions"
+          git config user.email "<>"
+      - name: Commit Edit Version
+        run: |
+          git add ./Android.mk qpm.json
+          git commit -m "Update Version and post restore"
+      # Then, we want to use the commit we have just made, and force push our tag to that commit
+      - name: Get Commit ID
+        id: get_commit_id
+        run: |
+          echo `git rev-parse HEAD`
+          echo ::set-output name=ID::`git rev-parse HEAD`
+      - name: Force create tag
+        run: |
+          git tag --force ${{ steps.get_tag_version.outputs.TAG }} ${{ steps.get_commid_id.outputs.ID }}
+      # Then, push, upload our artifacts, modify the config file to have soLink and debugSoLink
+      - name: Create and push version specific branch
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          git branch version-${{ steps.get_tag_version.outputs.TAG }}
+          git push -u origin version-${{ steps.get_tag_version.outputs.TAG }} --force --tags
+      # Get release that was created for this tag
+      - name: Get Release
+        uses: octokit/request-action@v2.x
+        id: get_release
+        with:
+          route: GET /repos/:repository/releases/tags/${{ steps.get_tag_version.outputs.TAG }}
+          repository: ${{ github.repository }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Get Release Upload URL
+        id: get_upload_url
+        run: |
+          url=$(echo "$response" | jq -r '.upload_url')
+          echo $url
+          echo "::set-output name=upload_url::$url"
+        env:
+          response:  ${{ steps.get_release.outputs.data }}
+      - name: Get Library Name
+        id: libname
+        run: |
+          cd ./libs/arm64-v8a/
+          pattern="libqraphicsplus*.so"
+          files=( $pattern )
+          echo ::set-output name=NAME::"${files[0]}"
+      # Upload our release assets
+      - name: Upload Release Asset
+        id: upload_release_asset
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ steps.get_upload_url.outputs.upload_url }}
+          asset_path: ./libs/arm64-v8a/${{ steps.libname.outputs.NAME }}
+          asset_name: ${{ steps.libname.outputs.NAME }}.so
+          asset_content_type: application/octet-stream
+      - name: Upload Debug Asset
+        id: upload_debug_asset
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ steps.get_upload_url.outputs.upload_url }}
+          asset_path: ./obj/local/arm64-v8a/${{ steps.libname.outputs.NAME }}
+          asset_name: debug_${{ steps.libname.outputs.NAME }}
+          asset_content_type: application/octet-stream
+
+      - name: Change QPM Package Info
+        run: |
+          ./QPM/QPM package edit-extra "branchName" "version-${{ steps.get_tag_version.outputs.TAG }}"
+          ./QPM/QPM package edit-extra "soLink" "${{ steps.upload_release_asset.outputs.browser_download_url }}"
+          ./QPM/QPM package edit-extra "debugSoLink" "${{ steps.upload_debug_asset.outputs.browser_download_url }}"
+      - name: Commit Changed package info
+        run: |
+          git add qpm.json
+          git commit -m "Updated qpm.json"
+
+      # Then, we want to use the commit we have just made, and force push our tag to that commit
+      - name: Get Commit ID
+        id: get_created_commit_id
+        run: |
+          echo `git rev-parse HEAD`
+          echo ::set-output name=ID::`git rev-parse HEAD`
+
+      - name: Push New Commit and Tag
+        run: |
+          git push origin HEAD:version-${{ steps.get_tag_version.outputs.TAG }} --force
+          git tag --force ${{ steps.get_tag_version.outputs.TAG }} ${{ steps.get_created_commit_id.outputs.ID }}
+          git push --tags --force
+
+          #     - name: Merge this branch into whatever branch we were originally built off of.
+          #       TODO
+
+      - name: QPM Publish
+        run: ./QPM/QPM publish

--- a/Android.mk
+++ b/Android.mk
@@ -37,7 +37,7 @@ LOCAL_MODULE := codegen_0_7_2
 LOCAL_EXPORT_C_INCLUDES := extern/codegen
 LOCAL_SRC_FILES := extern/libcodegen_0_7_2.so
 include $(PREBUILT_SHARED_LIBRARY)
-# Creating prebuilt for dependency: custom-types - version: 0.8.2
+# Creating prebuilt for dependency: custom-types - version: 0.8.3
 include $(CLEAR_VARS)
 LOCAL_MODULE := custom-types
 LOCAL_EXPORT_C_INCLUDES := extern/custom-types

--- a/include/hooks/OVRPlugin.hpp
+++ b/include/hooks/OVRPlugin.hpp
@@ -1,3 +1,3 @@
 #pragma once
 
-inline bool isQuest2;
+inline std::optional<bool> isQuest2;

--- a/qpm.json
+++ b/qpm.json
@@ -5,7 +5,7 @@
     "name": "Qraphics+",
     "id": "qraphicsplus",
     "version": "0.1.0",
-    "url": null,
+    "url": "https://github.com/nyamimi/QraphicsPlus/",
     "additionalData": {
       "headersOnly": true
     }

--- a/qpm.json
+++ b/qpm.json
@@ -6,7 +6,9 @@
     "id": "qraphicsplus",
     "version": "0.1.0",
     "url": null,
-    "additionalData": {}
+    "additionalData": {
+      "headersOnly": true
+    }
   },
   "dependencies": [
     {
@@ -35,6 +37,11 @@
     },
     {
       "id": "config-utils",
+      "versionRange": "*",
+      "additionalData": {}
+    },
+    {
+      "id": "conditional-dependencies",
       "versionRange": "*",
       "additionalData": {}
     }

--- a/shared/qraphics_api.hpp
+++ b/shared/qraphics_api.hpp
@@ -1,0 +1,50 @@
+#pragma once
+
+#include "GlobalNamespace/OVRPlugin.hpp"
+#include "conditional-dependencies/shared/main.hpp"
+
+#include <optional>
+#include <functional>
+#include <utility>
+
+namespace Qraphics {
+    class QraphicsAPI {
+
+        /// Sets the refresh rate of the screen
+        /// If null-opt, it will be set to the Qraphics+ configuration
+        static void setRefreshRate(int refreshRate) noexcept {
+            auto function = CondDep::Find<void, std::optional<int>>("qraphicsplus", "setRefreshRate");
+
+            if (function) {
+                function.value()(refreshRate);
+            }
+
+            GlobalNamespace::OVRPlugin::set_systemDisplayFrequency(refreshRate);
+        }
+
+        /// Sets the CPU level
+        /// If null-opt, it will be set to the Qraphics+ configuration
+        static void setCPULevel(int cpuLevel) noexcept {
+            auto function = CondDep::Find<void, std::optional<int>>("qraphicsplus", "setCPULevel");
+
+            if (function) {
+                function.value()(cpuLevel);
+            }
+
+            GlobalNamespace::OVRPlugin::set_cpuLevel(cpuLevel);
+        }
+
+        /// Sets the GPU level
+        /// If null-opt, it will be set to the Qraphics+ configuration
+        static void setGPULevel(int gpuLevel) noexcept {
+            auto function = CondDep::Find<void, std::optional<int>>("qraphicsplus", "setGPULevel");
+
+            if (function) {
+                function.value()(gpuLevel);
+            }
+
+            GlobalNamespace::OVRPlugin::set_gpuLevel(gpuLevel);
+        }
+
+    };
+}

--- a/shared/qraphics_api.hpp
+++ b/shared/qraphics_api.hpp
@@ -12,38 +12,63 @@ namespace Qraphics {
 
         /// Sets the refresh rate of the screen
         /// If null-opt, it will be set to the Qraphics+ configuration
-        static void setRefreshRate(int refreshRate) noexcept {
-            auto function = CondDep::Find<void, std::optional<int>>("qraphicsplus", "setRefreshRate");
+        static void setRefreshRate(std::optional<float> refreshRate) noexcept {
+            auto function = CondDep::Find<void, std::optional<float>>("qraphicsplus", "setRefreshRate");
 
             if (function) {
                 function.value()(refreshRate);
+                GlobalNamespace::OVRPlugin::set_systemDisplayFrequency(refreshRate.value());
+            } else {
+                static float initRefreshRate = GlobalNamespace::OVRPlugin::get_systemDisplayFrequency();
+
+                if (refreshRate) {
+                    GlobalNamespace::OVRPlugin::set_systemDisplayFrequency(refreshRate.value());
+                } else {
+                    GlobalNamespace::OVRPlugin::set_systemDisplayFrequency(initRefreshRate);
+                }
             }
 
-            GlobalNamespace::OVRPlugin::set_systemDisplayFrequency(refreshRate);
+
         }
 
         /// Sets the CPU level
         /// If null-opt, it will be set to the Qraphics+ configuration
-        static void setCPULevel(int cpuLevel) noexcept {
+        static void setCPULevel(std::optional<int> cpuLevel) noexcept {
             auto function = CondDep::Find<void, std::optional<int>>("qraphicsplus", "setCPULevel");
 
             if (function) {
                 function.value()(cpuLevel);
-            }
+                GlobalNamespace::OVRPlugin::set_cpuLevel(cpuLevel.value());
+            } else {
+                static int initCPULevel = GlobalNamespace::OVRPlugin::get_cpuLevel();
 
-            GlobalNamespace::OVRPlugin::set_cpuLevel(cpuLevel);
+                if (cpuLevel) {
+                    GlobalNamespace::OVRPlugin::set_cpuLevel(cpuLevel.value());
+                } else {
+                    GlobalNamespace::OVRPlugin::set_cpuLevel(initCPULevel);
+                }
+            }
         }
 
         /// Sets the GPU level
         /// If null-opt, it will be set to the Qraphics+ configuration
-        static void setGPULevel(int gpuLevel) noexcept {
+        static void setGPULevel(std::optional<int> gpuLevel) noexcept {
             auto function = CondDep::Find<void, std::optional<int>>("qraphicsplus", "setGPULevel");
 
             if (function) {
                 function.value()(gpuLevel);
+                GlobalNamespace::OVRPlugin::set_gpuLevel(gpuLevel.value());
+            } else {
+                static int initGPULevel = GlobalNamespace::OVRPlugin::get_gpuLevel();
+
+                if (gpuLevel) {
+                    GlobalNamespace::OVRPlugin::set_gpuLevel(gpuLevel.value());
+                } else {
+                    GlobalNamespace::OVRPlugin::set_gpuLevel(initGPULevel);
+                }
             }
 
-            GlobalNamespace::OVRPlugin::set_gpuLevel(gpuLevel);
+
         }
 
     };

--- a/shared/qraphics_api.hpp
+++ b/shared/qraphics_api.hpp
@@ -11,7 +11,7 @@ namespace Qraphics {
     class QraphicsAPI {
 
         /// Sets the refresh rate of the screen
-        /// If null-opt, it will be set to the Qraphics+ configuration
+        /// If null-opt, it will be set to the Qraphics+ configuration or the initial value
         static void setRefreshRate(std::optional<float> refreshRate) noexcept {
             auto function = CondDep::Find<void, std::optional<float>>("qraphicsplus", "setRefreshRate");
 
@@ -32,7 +32,7 @@ namespace Qraphics {
         }
 
         /// Sets the CPU level
-        /// If null-opt, it will be set to the Qraphics+ configuration
+        /// If null-opt, it will be set to the Qraphics+ configuration or the initial value
         static void setCPULevel(std::optional<int> cpuLevel) noexcept {
             auto function = CondDep::Find<void, std::optional<int>>("qraphicsplus", "setCPULevel");
 
@@ -51,7 +51,7 @@ namespace Qraphics {
         }
 
         /// Sets the GPU level
-        /// If null-opt, it will be set to the Qraphics+ configuration
+        /// If null-opt, it will be set to the Qraphics+ configuration or the initial value
         static void setGPULevel(std::optional<int> gpuLevel) noexcept {
             auto function = CondDep::Find<void, std::optional<int>>("qraphicsplus", "setGPULevel");
 

--- a/src/QraphicsPlus.cpp
+++ b/src/QraphicsPlus.cpp
@@ -42,7 +42,7 @@ void QraphicsPlus::QraphicsPlusViewController::DidActivate(
         AddConfigValueIncrementFloat(container->get_transform(), getQraphicsPlusConfig().Resolution, 1, 0.1f, 0.5f, 1.5f);
         if (isQuest2) {
             BeatSaberUI::CreateDropdown(container->get_transform(), "Refresh Rate", refreshRates[getQraphicsPlusConfig().RefreshRate.GetValue()], refreshRates,
-                [](std::string value) {
+                [](const std::string& value) {
                     getQraphicsPlusConfig().RefreshRate.SetValue(std::distance(refreshRates.begin(), std::find(refreshRates.begin(), refreshRates.end(), value)));
                     
                     // Force OVRPlugin to read our config.

--- a/src/hooks/OVRPlugin.cpp
+++ b/src/hooks/OVRPlugin.cpp
@@ -5,14 +5,15 @@
 #include "GlobalNamespace/OVRPlugin.hpp"
 
 #include "conditional-dependencies/shared/main.hpp"
+#include "qraphics_api.hpp"
 
 using namespace GlobalNamespace;
 
-std::optional<int> refreshRateAPI;
+std::optional<float> refreshRateAPI;
 std::optional<int> cpuLevelAPI;
 std::optional<int> gpuLevelAPI;
 
-EXPOSE_API(setRefreshRate, void, std::optional<int> refreshRate) {
+EXPOSE_API(setRefreshRate, void, std::optional<float> refreshRate) {
     refreshRateAPI = refreshRate;
 }
 

--- a/src/hooks/OVRPlugin.cpp
+++ b/src/hooks/OVRPlugin.cpp
@@ -4,7 +4,25 @@
 
 #include "GlobalNamespace/OVRPlugin.hpp"
 
+#include "conditional-dependencies/shared/main.hpp"
+
 using namespace GlobalNamespace;
+
+std::optional<int> refreshRateAPI;
+std::optional<int> cpuLevelAPI;
+std::optional<int> gpuLevelAPI;
+
+EXPOSE_API(setRefreshRate, void, std::optional<int> refreshRate) {
+    refreshRateAPI = refreshRate;
+}
+
+EXPOSE_API(setGPULevel, void, std::optional<int> gpuLevel) {
+    gpuLevelAPI = gpuLevel;
+}
+
+EXPOSE_API(setCPULevel, void, std::optional<int> cpuLevel) {
+    cpuLevelAPI = cpuLevel;
+}
 
 MAKE_HOOK_OFFSETLESS(
     OVRPlugin_set_systemDisplayFrequency,
@@ -12,7 +30,8 @@ MAKE_HOOK_OFFSETLESS(
     OVRPlugin* self,
     float value
 ) {
-    isQuest2 = value == 90.0f;
+    if (isQuest2 == std::nullopt)
+        isQuest2 = std::make_optional(value == 90.0f);
 
     float systemDisplayFrequency = 60.0f;
 
@@ -31,6 +50,9 @@ MAKE_HOOK_OFFSETLESS(
         break;
     }
 
+    if (refreshRateAPI)
+        systemDisplayFrequency = refreshRateAPI.value();
+
     OVRPlugin_set_systemDisplayFrequency(self, systemDisplayFrequency);
 }
 
@@ -40,7 +62,12 @@ MAKE_HOOK_OFFSETLESS(
     OVRPlugin* self,
     int value
 ) {
-    OVRPlugin_set_cpuLevel(self, getQraphicsPlusConfig().CpuLevel.GetValue());
+    int level = getQraphicsPlusConfig().CpuLevel.GetValue();
+
+    if (cpuLevelAPI)
+        level = cpuLevelAPI.value();
+
+    OVRPlugin_set_cpuLevel(self, level);
 }
 
 MAKE_HOOK_OFFSETLESS(
@@ -49,7 +76,12 @@ MAKE_HOOK_OFFSETLESS(
     OVRPlugin* self,
     int value
 ) {
-    OVRPlugin_set_gpuLevel(self, getQraphicsPlusConfig().GpuLevel.GetValue());
+    int level = getQraphicsPlusConfig().GpuLevel.GetValue();
+
+    if (gpuLevelAPI)
+        level = gpuLevelAPI.value();
+
+    OVRPlugin_set_gpuLevel(self, level);
 }
 
 void QraphicsPlus::Hooks::OVRPlugin() {


### PR DESCRIPTION
While the validity of the current build is still unsure, the changes do not seem big enough to cause a major problem. However, you can always test out the build which the CI has provided and either fix the problems yourself or report them so it can be fixed in the PR.

Notable changes are that Quest2 is now a late init constant (to fix the missing refresh rate option)
API to set the refresh rate, cpu level and gpu level accordingly, with a null fallback that resets to:
- When Qraphics+ is running: The user's config of said option
- When Qraphics+ is not running: The initial value of said option
